### PR TITLE
catch ispath errors on discovery

### DIFF
--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -79,8 +79,9 @@ function find_binary(name, prefixes::Vector{String}=String[])
     @trace("Checking for $name in $locations")
     paths = [joinpath(location, name) for location in locations]
     try
-        paths = unique(filter(ispath, paths))
+        paths = filter(ispath, paths)
     end
+    paths = unique(paths)
     if isempty(paths)
         error("Could not find $name binary")
     end

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -78,7 +78,9 @@ function find_binary(name, prefixes::Vector{String}=String[])
 
     @trace("Checking for $name in $locations")
     paths = [joinpath(location, name) for location in locations]
-    paths = unique(filter(ispath, paths))
+    try
+        paths = unique(filter(ispath, paths))
+    end
     if isempty(paths)
         error("Could not find $name binary")
     end


### PR DESCRIPTION
`paths` might contain system paths where running `ls` is forbidden. This change simply allows the program to continue even if the exception is raised on some paths.