### PR TITLE
Separate find_host_compiler as an independently useful function. Chan…

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -10,6 +10,8 @@ const toolkits = [v"1.0", v"1.1",
                   v"9.0"]
 
 
+const cudnns = [v"1.0", v"2.0", v"3.0", v"4.0", v"5.0", v"5.1", v"6.0", v"7.0"]
+
 struct VersionRange
     lower::VersionNumber
     upper::VersionNumber


### PR DESCRIPTION
…ge windows/osx host_compiler_version to v"0" instead of nothing to avoid type error.
This setup works on vs2015 and cuda9 without problems.