### PR TITLE
more fixes

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -80,7 +80,7 @@ function msvc_supported(msvc::VersionNumber, toolkit::VersionNumber)
         end
     end
 
-    msvc_num = parse(Int, string(msvc.major, msvc.minor))
+    msvc_num = msvc.major * 100 + msvc.minor # parse(Int, string(msvc.major, msvc.minor)) # does not work for v"19.0"
     return in(msvc_num, msvc_range)
 end
 


### PR DESCRIPTION
* Fixed msvc_num calculation in compatibility.jl
* Fixed read(::CmdRedirect,String) problem in discovery.jl.
* I think we still need to try version suffixes because lots of libraries (curand, cublas), not just cudart uses them.
