### PR TITLE
Rework discovery again.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,18 +35,13 @@ macro test_something(ex...)
     end
 end
 
-toolkit = @test_something find_toolkit()
-toolkit_version = find_toolkit_version(toolkit)
+dirs = find_toolkit()
+@test !isempty(dirs)
+ver = find_toolkit_version(dirs)
 
-if haskey(ENV, "CI")
-    find_driver()
-else
-    @test_something find_driver()
-end
-
-@test_something find_cuda_binary("nvcc", toolkit)
-@test_something find_cuda_library("cudart", toolkit)
+@test_something find_cuda_binary("nvcc", dirs)
+@test_something find_cuda_library("cudart", dirs)
 @test_something find_host_compiler()
-@test_something find_host_compiler(toolkit_version)
-@test_something find_toolchain(toolkit)
-@test_something find_toolchain(toolkit, toolkit_version)
+@test_something find_host_compiler(ver)
+@test_something find_toolchain(dirs)
+@test_something find_toolchain(dirs, ver)


### PR DESCRIPTION
Hopefully this is the last time I need to redesign this interface. As mentioned in https://github.com/JuliaGPU/CUDAapi.jl/pull/29#issuecomment-357962283, some distros (Debian, Ubuntu, so not like we can ignore them) like to split CUDA all over `/` so our notion of "finding _the_ toolkit directory" doesn't work. Instead, work with a list of candidate directories now.

Also, remove `find_driver` as that needs to be system-wide anyway (ie. not local to the CUDA toolkit).