### PR TITLE
Handle multiple device libraries.

### DIFF
--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -360,11 +360,8 @@ function find_libcudadevrt(toolkit_dirs)
         name = "libcudadevrt.a"
     elseif Sys.iswindows()
         name = "libcudadevrt.lib"
-    end
-
-    if name === nothing
-        @error("What even are static libraries")
-        return nothing
+    else
+        error("No support for discovering the CUDA device runtime library on your platform, please file an issue.")
     end
 
     # figure out locations
@@ -381,18 +378,16 @@ function find_libcudadevrt(toolkit_dirs)
         end
     end
 
-    @trace "Looking for library $name" locations=all_locations
+    @trace "Looking for CUDA device runtime library $name" locations=all_locations
+    paths = filter(isfile, map(location->joinpath(location, name), all_locations))
 
-    candidates = filter(isfile,
-        map(location->joinpath(location, name), all_locations))
-
-    @trace "Found candidates for library $name" candidates
-
-    if length(candidates) == 1
-        return first(candidates)
+    if isempty(paths)
+        return nothing
+    else
+        path = first(paths)
+        @debug "Found CUDA device runtime library $(basename(path)) at $(dirname(path))"
+        return path
     end
-
-    return nothing
 end
 
 function find_host_compiler(toolkit_version=nothing)


### PR DESCRIPTION
Fix https://github.com/JuliaGPU/CUDAnative.jl/pull/356#discussion_r260371036

```
julia> tk = CUDAapi.find_toolkit()
┌ Debug: Request to look for binary nvcc
│   locations = 0-element Array{String,1}
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Looking for binary nvcc
│   locations =
│    8-element Array{String,1}:
│     "/usr/local/nvidia/bin"
│     "/usr/local/cuda/bin"  
│     "/usr/local/sbin"      
│     "/usr/local/bin"       
│     "/usr/sbin"            
│     "/usr/bin"             
│     "/sbin"                
│     "/bin"                 
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Found binary nvcc at /usr/local/cuda/bin
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/discovery.jl:142
┌ Debug: Looking for CUDA toolkit via nvcc binary
│   path = "/usr/local/cuda/bin/nvcc"
│   dir = "/usr/local/cuda"
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Request to look for library cudart
│   locations = 0-element Array{String,1}
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Looking for library libcudart.so, libcudart.so.10, libcudart.so.10.1, libcudart.so.10.0, libcudart.so.9, libcudart.so.9.2, libcudart.so.9.1, libcudart.so.9.0, libcudart.so.8, libcudart.so.8.0, libcudart.so.7, libcudart.so.7.5, libcudart.so.7.0, libcudart.so.6, libcudart.so.6.5, libcudart.so.6.0, libcudart.so.5, libcudart.so.5.5, libcudart.so.5.0, libcudart.so.4, libcudart.so.4.2, libcudart.so.4.1, libcudart.so.4.0, libcudart.so.3, libcudart.so.3.2, libcudart.so.3.1, libcudart.so.3.0, libcudart.so.2, libcudart.so.2.2, libcudart.so.2.1, libcudart.so.2.0, libcudart.so.1, libcudart.so.1.1, libcudart.so.1.0
│   locations = 0-element Array{String,1}
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Found library libcudart.so at /usr/local/cuda-10.0/targets/x86_64-linux/lib/libcudart.so
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/discovery.jl:91
┌ Debug: Looking for CUDA toolkit via CUDA runtime library
│   path = "/usr/local/cuda-10.0/targets/x86_64-linux/lib/libcudart.so"
│   dir = "/usr/local/cuda-10.0/targets/x86_64-linux"
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Looking for CUDA toolkit via default installation directories
│   dirs =
│    1-element Array{Any,1}:
│     "/usr/local/cuda-10.0"
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Found CUDA toolkit at /usr/local/cuda-10.0, /usr/local/cuda-10.0/targets/x86_64-linux
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/discovery.jl:271
2-element Array{String,1}:
 "/usr/local/cuda-10.0"                     
 "/usr/local/cuda-10.0/targets/x86_64-linux"

julia> CUDAapi.find_libcudadevrt(tk)
┌ Debug: Request to look for libcudadevrt 
│   locations =
│    2-element Array{String,1}:
│     "/usr/local/cuda-10.0"                     
│     "/usr/local/cuda-10.0/targets/x86_64-linux"
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Looking for library libcudadevrt.a
│   locations =
│    6-element Array{String,1}:
│     "/usr/local/cuda-10.0"                           
│     "/usr/local/cuda-10.0/lib"                       
│     "/usr/local/cuda-10.0/lib64"                     
│     "/usr/local/cuda-10.0/targets/x86_64-linux"      
│     "/usr/local/cuda-10.0/targets/x86_64-linux/lib"  
│     "/usr/local/cuda-10.0/targets/x86_64-linux/lib64"
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8
┌ Debug: Found candidates for library libcudadevrt.a
│   candidates =
│    2-element Array{String,1}:
│     "/usr/local/cuda-10.0/lib64/libcudadevrt.a"                   
│     "/usr/local/cuda-10.0/targets/x86_64-linux/lib/libcudadevrt.a"
└ @ CUDAapi ~/.julia/packages/CUDAapi/KdDtB/src/CUDAapi.jl:8

julia> ans
```