### PR TITLE
Methods for checking the availability of CUDA and CUDA GPUs.

### DIFF
--- a/src/CUDAapi.jl
+++ b/src/CUDAapi.jl
@@ -9,8 +9,11 @@ macro trace(ex...)
 end
 
 include("util.jl")
+
 include("compatibility.jl")
 include("discovery.jl")
+include("availability.jl")
+
 include("library_types.jl")
 
 end

--- a/src/availability.jl
+++ b/src/availability.jl
@@ -1,0 +1,63 @@
+export has_cuda, has_cuda_gpu
+
+"""
+    has_cuda()::Bool
+
+Check whether the local system provides an installation of the CUDA driver and toolkit.
+Use this function if your code loads packages that require CUDA, such as CuArrays.jl.
+
+Note that CUDA-dependent packages might still fail to load if the installation is broken,
+so it's recommended to guard against that and print a warning to inform the user:
+
+```
+using CUDAapi
+if has_cuda()
+    try
+        using CuArrays
+    catch ex
+        @warn "CUDA is installed, but CuArrays.jl fails to load" exception=(ex,catch_backtrace())
+    end
+end
+```
+"""
+function has_cuda()
+    toolkit_dirs = find_toolkit()
+
+    # check for the CUDA driver library
+    libcuda = find_cuda_library("cuda", toolkit_dirs)
+    return libcuda !== nothing
+end
+
+"""
+    has_cuda_gpu()::Bool
+
+Check whether the local system provides an installation of the CUDA driver and toolkit, and
+if it contains a CUDA-capable GPU. See [`has_cuda`](@ref) for more details.
+
+Note that this function initializes the CUDA API in order to check for the number of GPUs.
+"""
+function has_cuda_gpu()
+    toolkit_dirs = find_toolkit()
+
+    # find the CUDA driver library
+    libcuda = find_cuda_library("cuda", toolkit_dirs)
+    if libcuda === nothing
+        return false
+    end
+    lib = Libdl.dlopen(libcuda)
+
+    # initialize the API
+    cuInit = Libdl.dlsym(lib, :cuInit)
+    status = ccall(cuInit, Cint, (Cuint,), 0)
+    if status != 0
+        @warn "CUDA is installed, but fails to load (error code $status)"
+        return false
+    end
+
+    # count the GPUs
+    cuDeviceGetCount = Libdl.dlsym(lib, :cuDeviceGetCount)
+    count_ref = Ref{Cint}()
+    status = ccall(cuDeviceGetCount, Cint, (Ptr{Cint},), count_ref)
+    @assert status == 0
+    return count_ref[] > 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,3 +71,8 @@ end
         end
     end
 end
+
+@testset "availability" begin
+    @test isa(has_cuda(), Bool)
+    @test isa(has_cuda_gpu(), Bool)
+end


### PR DESCRIPTION
Companion of the CUDAdrv/CUDAnative/CuArrays PRs that remove the ability to load the package without CUDA. Removing this ability simplifies the package's initialization, without putting much of an additional burden of the user (who before had to check whether the loaded packages were actually functional anyway). See discussion in https://github.com/JuliaGPU/CuArrays.jl/pull/372

Note that even if the `has_cuda` or `has_cuda_gpu` checks return `true`, packages _might_ still fail to load if the CUDA installation is broken or if there's something wrong with the GPU. My reasoning here is that if users have gone to the length of installing CUDA in combination with a CUDA-capable package (like Flux), initialization of said package shouldn't silently decide to not use the GPU because of a configuration issue. See the docstrings for a proposed template.

cc @MikeInnes @ChrisRackauckas