### PR TITLE
Expand CI testing to cover new Julia releases, no-CUDA setups, ARM, FreeBSD

### DIFF
--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -1,26 +1,28 @@
-$ErrorActionPreference = "Stop"
+if ($env:cuda_version != "nill") {
+    $ErrorActionPreference = "Stop"
 
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
-$cuda_installers = @{}
-$cuda_installers.Add('8.0', 'https://developer.nvidia.com/compute/cuda/8.0/prod/local_installers/cuda_8.0.44_windows-exe')
-$cuda_installers.Add('9.0', 'https://developer.nvidia.com/compute/cuda/9.0/prod/local_installers/cuda_9.0.176_windows-exe')
-$cuda_installers.Add('9.1', 'https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.85_windows')
-$cuda_installers.Add('9.2', 'https://developer.nvidia.com/compute/cuda/9.2/Prod/local_installers/cuda_9.2.88_windows')
-$cuda_installers.Add('10.0', 'https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_411.31_win10')
-$cuda_installers.Add('10.1', 'https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.105_418.96_win10.exe')
+    $cuda_installers = @{}
+    $cuda_installers.Add('8.0', 'https://developer.nvidia.com/compute/cuda/8.0/prod/local_installers/cuda_8.0.44_windows-exe')
+    $cuda_installers.Add('9.0', 'https://developer.nvidia.com/compute/cuda/9.0/prod/local_installers/cuda_9.0.176_windows-exe')
+    $cuda_installers.Add('9.1', 'https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.85_windows')
+    $cuda_installers.Add('9.2', 'https://developer.nvidia.com/compute/cuda/9.2/Prod/local_installers/cuda_9.2.88_windows')
+    $cuda_installers.Add('10.0', 'https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_411.31_win10')
+    $cuda_installers.Add('10.1', 'https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.105_418.96_win10.exe')
 
-$cuda_installer = $cuda_installers.Get_Item($env:cuda_version)
-Start-FileDownload $cuda_installer -FileName cuda.exe
+    $cuda_installer = $cuda_installers.Get_Item($env:cuda_version)
+    Start-FileDownload $cuda_installer -FileName cuda.exe
 
-# Source: NVIDIA CUDA Installation Guide for Microsoft Windows
-$cuda_components = @{}
-$cuda_components.Add('8.0', @("compiler_8.0", "cudart_8.0", "visual_studio_integration_8.0"))
-$cuda_components.Add('9.0', @("compiler_9.0", "cudart_9.0", "visual_studio_integration_9.0"))
-$cuda_components.Add('9.1', @("nvcc_9.1", "cudart_9.1", "visual_studio_integration_9.1"))
-$cuda_components.Add('9.2', @("nvcc_9.2", "cudart_9.2", "visual_studio_integration_9.2"))
-$cuda_components.Add('10.0', @("nvcc_10.0", "cudart_10.0", "visual_studio_integration_10.0"))
-$cuda_components.Add('10.1', @("nvcc_10.1", "cudart_10.1", "visual_studio_integration_10.1"))
+    # Source: NVIDIA CUDA Installation Guide for Microsoft Windows
+    $cuda_components = @{}
+    $cuda_components.Add('8.0', @("compiler_8.0", "cudart_8.0", "visual_studio_integration_8.0"))
+    $cuda_components.Add('9.0', @("compiler_9.0", "cudart_9.0", "visual_studio_integration_9.0"))
+    $cuda_components.Add('9.1', @("nvcc_9.1", "cudart_9.1", "visual_studio_integration_9.1"))
+    $cuda_components.Add('9.2', @("nvcc_9.2", "cudart_9.2", "visual_studio_integration_9.2"))
+    $cuda_components.Add('10.0', @("nvcc_10.0", "cudart_10.0", "visual_studio_integration_10.0"))
+    $cuda_components.Add('10.1', @("nvcc_10.1", "cudart_10.1", "visual_studio_integration_10.1"))
 
-$components = $cuda_components.Get_Item($env:cuda_version)
-.\cuda.exe -s @components | Out-Null
+    $components = $cuda_components.Get_Item($env:cuda_version)
+    .\cuda.exe -s @components | Out-Null
+}

--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -1,4 +1,4 @@
-if ($env:cuda_version != "nill") {
+if ($env:cuda_version -ne "nil") {
     $ErrorActionPreference = "Stop"
 
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,13 +2,26 @@ environment:
   JULIA_DEBUG: CUDAapi
   matrix:
   # Julia versions
-  - julia_version: 0.7
-    cuda_version: 8.0
+    # No CUDA
   - julia_version: 1.0
+    cuda_version: nill
+  - julia_version: 1.2
+    cuda_version: nill
+  - julia_version: 1.3
+    cuda_version: nill
+  - julia_version: latest
+    cuda_version: nill
+    # CUDA 8.0
+  - julia_version: 1.0
+    cuda_version: 8.0
+  - julia_version: 1.2
+    cuda_version: 8.0
+  - julia_version: 1.3
     cuda_version: 8.0
   - julia_version: latest
     cuda_version: 8.0
-  # CUDA versions
+
+  # CUDA versions on 1.0
   - julia_version: 1.0
     cuda_version: 9.0
   - julia_version: 1.0
@@ -19,6 +32,17 @@ environment:
     cuda_version: 10.0
   - julia_version: 1.0
     cuda_version: 10.1
+  # CUDA versions on latest
+  - julia_version: latest
+    cuda_version: 9.0
+  - julia_version: latest
+    cuda_version: 9.1
+  - julia_version: latest
+    cuda_version: 9.2
+  - julia_version: latest
+    cuda_version: 10.0
+  - julia_version: latest
+    cuda_version: 10.1
 
 platform:
   - x64
@@ -27,6 +51,16 @@ matrix:
  allow_failures:
   - julia_version: latest
     cuda_version: 8.0
+  - julia_version: latest
+    cuda_version: 9.0
+  - julia_version: latest
+    cuda_version: 9.1
+  - julia_version: latest
+    cuda_version: 9.2
+  - julia_version: latest
+    cuda_version: 10.0
+  - julia_version: latest
+    cuda_version: 10.1
 
 notifications:
   - provider: Email

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,13 +4,13 @@ environment:
   # Julia versions
     # No CUDA
   - julia_version: 1.0
-    cuda_version: nill
+    cuda_version: nil
   - julia_version: 1.2
-    cuda_version: nill
+    cuda_version: nil
   - julia_version: 1.3
-    cuda_version: nill
+    cuda_version: nil
   - julia_version: latest
-    cuda_version: nill
+    cuda_version: nil
     # CUDA 8.0
   - julia_version: 1.0
     cuda_version: 8.0

--- a/.cirrus.linux
+++ b/.cirrus.linux
@@ -1,0 +1,31 @@
+#!/bin/bash -uxe
+
+if [$CUDA != nill]; then
+    
+    sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/7fa2af80.pub
+
+    declare -A installers
+    installers["8.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/cuda-repo-ubuntu1604_8.0.61-1_ppc64el.deb"
+    installers["9.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/cuda-repo-ubuntu1604_9.0.176-1_ppc64el.deb"
+    installers["9.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/cuda-repo-ubuntu1604_9.1.85-1_ppc64el.deb"
+    installers["9.2"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/cuda-repo-ubuntu1604_9.2.148-1_ppc64el.deb"
+    installers["10.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/cuda-repo-ubuntu1604_10.0.130-1_ppc64el.deb"
+    installers["10.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/cuda-repo-ubuntu1604_10.1.105-1_ppc64el.deb"
+
+    declare -A components
+    components["8.0"]="cuda-drivers cuda-core-8-0 cuda-cudart-dev-8-0"
+    components["9.0"]="cuda-drivers cuda-core-9-0 cuda-cudart-dev-9-0"
+    components["9.1"]="cuda-drivers cuda-core-9-1 cuda-cudart-dev-9-1 cuda-nvtx-9-1"
+    components["9.2"]="cuda-drivers cuda-core-9-2 cuda-cudart-dev-9-2 cuda-nvtx-9-2"
+    components["10.0"]="cuda-drivers cuda-core-10-0 cuda-cudart-dev-10-0 cuda-nvtx-10-0"
+    components["10.1"]="cuda-drivers cuda-core-10-1 cuda-cudart-dev-10-1 cuda-nvtx-10-1"
+
+    installer=${installers[$CUDA]}
+    wget -O cuda.deb "$installer"
+
+    sudo dpkg -i cuda.deb
+
+    sudo apt-get update
+    sudo apt-get install -y ${components[$CUDA]}
+
+fi

--- a/.cirrus.linux
+++ b/.cirrus.linux
@@ -1,6 +1,6 @@
 #!/bin/bash -uxe
 
-if [$CUDA != nill]; then
+if [$CUDA != nil]; then
     
     sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/7fa2af80.pub
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,27 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.3
+        CUDA: nill
+      - JULIA_VERSION: nightly
+        CUDA: nill
+      - JULIA_VERSION: 1.3
+        CUDA: 8.0
+      - JULIA_VERSION: nightly
+        CUDA: 8.0
+      - JULIA_VERSION: 1.3
+        CUDA: 10.1
+      - JULIA_VERSION: nightly
+        CUDA: 10.1
+  install_script:
+    - ./.cirrus.linux
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+  coverage_script:
+    - cirrusjl coverage codecov coveralls

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,9 @@ task:
   env:
     matrix:
       - JULIA_VERSION: 1.3
-        CUDA: nill
+        CUDA: nil
       - JULIA_VERSION: nightly
-        CUDA: nill
+        CUDA: nil
       - JULIA_VERSION: 1.3
         CUDA: 8.0
       - JULIA_VERSION: nightly

--- a/.drone.linux
+++ b/.drone.linux
@@ -1,0 +1,32 @@
+#!/bin/bash -uxe
+
+if [$CUDA != "nill"]; then
+    # TODO: Needs correcting to arm installers 
+    
+    sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
+
+    declare -A installers
+    installers["8.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb"
+    installers["9.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.0.176-1_amd64.deb"
+    installers["9.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.1.85-1_amd64.deb"
+    installers["9.2"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.2.148-1_amd64.deb"
+    installers["10.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb"
+    installers["10.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.1.105-1_amd64.deb"
+
+    declare -A components
+    components["8.0"]="cuda-drivers cuda-core-8-0 cuda-cudart-dev-8-0"
+    components["9.0"]="cuda-drivers cuda-core-9-0 cuda-cudart-dev-9-0"
+    components["9.1"]="cuda-drivers cuda-core-9-1 cuda-cudart-dev-9-1 cuda-nvtx-9-1"
+    components["9.2"]="cuda-drivers cuda-core-9-2 cuda-cudart-dev-9-2 cuda-nvtx-9-2"
+    components["10.0"]="cuda-drivers cuda-core-10-0 cuda-cudart-dev-10-0 cuda-nvtx-10-0"
+    components["10.1"]="cuda-drivers cuda-core-10-1 cuda-cudart-dev-10-1 cuda-nvtx-10-1"
+
+    installer=${installers[$CUDA]}
+    wget -O cuda.deb "$installer"
+
+    sudo dpkg -i cuda.deb
+
+    sudo apt-get update
+    sudo apt-get install -y ${components[$CUDA]}
+
+fi

--- a/.drone.linux
+++ b/.drone.linux
@@ -1,6 +1,6 @@
 #!/bin/bash -uxe
 
-if [$CUDA != "nill"]; then
+if [$CUDA != "nil"]; then
     # TODO: Needs correcting to arm installers 
     
     sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ steps:
 - name: build
   image: julia:1.3
   environment:
-    CUDA: nill
+    CUDA: nil
   commands:
      - ./.drone.linux
      - uname -a
@@ -28,7 +28,7 @@ steps:
 - name: build
   image: julia:1.3
   environment:
-    CUDA: nill
+    CUDA: nil
   commands:
       - ./.drone.linux
       - uname -a

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
 - name: build
-  image: julia:1.3
+  image: julia:1.3.0-rc2
   environment:
     CUDA: nil
   commands:
@@ -26,7 +26,7 @@ platform:
 
 steps:
 - name: build
-  image: julia:1.3
+  image: julia:1.3.0-rc2
   environment:
     CUDA: nil
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,35 @@
+kind: pipeline
+name: linux-arm-1.3
+
+platform:
+ os: linux
+ arch: arm
+
+steps:
+- name: build
+  image: julia:1.3
+  environment:
+    CUDA: nill
+  commands:
+     - ./.drone.linux
+     - uname -a
+     - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-aarch64-1.3
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:1.3
+  environment:
+    CUDA: nill
+  commands:
+      - ./.drone.linux
+      - uname -a
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'

--- a/.travis.linux
+++ b/.travis.linux
@@ -1,27 +1,30 @@
 #!/bin/bash -uxe
 
-sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
+if [$CUDA != "nill"]; then
+    sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
 
-declare -A installers
-installers["8.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb"
-installers["9.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.0.176-1_amd64.deb"
-installers["9.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.1.85-1_amd64.deb"
-installers["9.2"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.2.148-1_amd64.deb"
-installers["10.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb"
-installers["10.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.1.105-1_amd64.deb"
+    declare -A installers
+    installers["8.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_8.0.61-1_amd64.deb"
+    installers["9.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.0.176-1_amd64.deb"
+    installers["9.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.1.85-1_amd64.deb"
+    installers["9.2"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.2.148-1_amd64.deb"
+    installers["10.0"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb"
+    installers["10.1"]="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.1.105-1_amd64.deb"
 
-declare -A components
-components["8.0"]="cuda-drivers cuda-core-8-0 cuda-cudart-dev-8-0"
-components["9.0"]="cuda-drivers cuda-core-9-0 cuda-cudart-dev-9-0"
-components["9.1"]="cuda-drivers cuda-core-9-1 cuda-cudart-dev-9-1 cuda-nvtx-9-1"
-components["9.2"]="cuda-drivers cuda-core-9-2 cuda-cudart-dev-9-2 cuda-nvtx-9-2"
-components["10.0"]="cuda-drivers cuda-core-10-0 cuda-cudart-dev-10-0 cuda-nvtx-10-0"
-components["10.1"]="cuda-drivers cuda-core-10-1 cuda-cudart-dev-10-1 cuda-nvtx-10-1"
+    declare -A components
+    components["8.0"]="cuda-drivers cuda-core-8-0 cuda-cudart-dev-8-0"
+    components["9.0"]="cuda-drivers cuda-core-9-0 cuda-cudart-dev-9-0"
+    components["9.1"]="cuda-drivers cuda-core-9-1 cuda-cudart-dev-9-1 cuda-nvtx-9-1"
+    components["9.2"]="cuda-drivers cuda-core-9-2 cuda-cudart-dev-9-2 cuda-nvtx-9-2"
+    components["10.0"]="cuda-drivers cuda-core-10-0 cuda-cudart-dev-10-0 cuda-nvtx-10-0"
+    components["10.1"]="cuda-drivers cuda-core-10-1 cuda-cudart-dev-10-1 cuda-nvtx-10-1"
 
-installer=${installers[$CUDA]}
-wget -O cuda.deb "$installer"
+    installer=${installers[$CUDA]}
+    wget -O cuda.deb "$installer"
 
-sudo dpkg -i cuda.deb
+    sudo dpkg -i cuda.deb
 
-sudo apt-get update
-sudo apt-get install -y ${components[$CUDA]}
+    sudo apt-get update
+    sudo apt-get install -y ${components[$CUDA]}
+
+fi

--- a/.travis.linux
+++ b/.travis.linux
@@ -1,6 +1,6 @@
 #!/bin/bash -uxe
 
-if [$CUDA != "nill"]; then
+if [$CUDA != "nil"]; then
     sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
 
     declare -A installers

--- a/.travis.osx
+++ b/.travis.osx
@@ -1,29 +1,33 @@
 #!/bin/bash -uxe
 
-brew update
+if [$CUDA != "nill"]; then
 
-# upgrade Bash to version 4, for associative array support
-if [[ ${BASH_VERSINFO[0]} < 4 ]]; then
-    brew install bash
-    /usr/local/bin/bash -uxe $0
-    exit $?
+    brew update
+
+    # upgrade Bash to version 4, for associative array support
+    if [[ ${BASH_VERSINFO[0]} < 4 ]]; then
+        brew install bash
+        /usr/local/bin/bash -uxe $0
+        exit $?
+    fi
+
+    declare -A installers
+    installers["7.5"]="http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.27_mac.dmg"
+    installers["8.0"]="https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_mac-dmg"
+    installers["9.0"]="https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_mac-dmg"
+    installers["9.1"]="https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.128_mac"
+    installers["9.2"]="https://developer.nvidia.com/compute/cuda/9.2/Prod/local_installers/cuda_9.2.64_mac"
+    installers["10.0"]="https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_mac"
+    installers["10.1"]="https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.105_mac.dmg"
+
+    installer=${installers[$CUDA]}
+    wget -O cuda.dmg "$installer"
+
+    brew install p7zip
+    7z x cuda.dmg
+    [[ -f 5.hfs ]] && 7z x 5.hfs
+
+    brew install gnu-tar
+    sudo gtar -x --skip-old-files -f CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/Resources/payload/cuda_mac_installer_tk.tar.gz -C /
+
 fi
-
-declare -A installers
-installers["7.5"]="http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.27_mac.dmg"
-installers["8.0"]="https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_mac-dmg"
-installers["9.0"]="https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_mac-dmg"
-installers["9.1"]="https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.128_mac"
-installers["9.2"]="https://developer.nvidia.com/compute/cuda/9.2/Prod/local_installers/cuda_9.2.64_mac"
-installers["10.0"]="https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_mac"
-installers["10.1"]="https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.105_mac.dmg"
-
-installer=${installers[$CUDA]}
-wget -O cuda.dmg "$installer"
-
-brew install p7zip
-7z x cuda.dmg
-[[ -f 5.hfs ]] && 7z x 5.hfs
-
-brew install gnu-tar
-sudo gtar -x --skip-old-files -f CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/Resources/payload/cuda_mac_installer_tk.tar.gz -C /

--- a/.travis.osx
+++ b/.travis.osx
@@ -1,6 +1,6 @@
 #!/bin/bash -uxe
 
-if [$CUDA != "nill"]; then
+if [$CUDA != "nil"]; then
 
     brew update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 matrix:
   include:
     # linux builds
-    - env: CUDA=nill
+    - env: CUDA=nil
       os: linux
       dist: xenial
     - env: CUDA=8.0
@@ -40,7 +40,7 @@ matrix:
       os: linux
       dist: xenial
     # osx builds
-    - env: CUDA=nill
+    - env: CUDA=nil
       os: osx
       osx_image: xcode7.3
     - env: CUDA=7.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ sudo: required
 notifications:
   email: false
 
-julia: 0.7
+julia:
+  - 1.0
+  - 1.2
+  - 1.3
+  - nightly
 
 env:
   global:
@@ -14,6 +18,9 @@ env:
 matrix:
   include:
     # linux builds
+    - env: CUDA=nill
+      os: linux
+      dist: xenial
     - env: CUDA=8.0
       os: linux
       dist: xenial
@@ -33,6 +40,9 @@ matrix:
       os: linux
       dist: xenial
     # osx builds
+    - env: CUDA=nill
+      os: osx
+      osx_image: xcode7.3
     - env: CUDA=7.5
       os: osx
       osx_image: xcode7.3


### PR DESCRIPTION
This includes a few changes:

- Update from `0.7 / nightly` to `1.0 / 1.2 / 1.3 / nightly` on the major platforms
- Add ARM (drone) and FreeBSD (cirrus)
    - ARM CUDA installers need correct paths (couldn't find the installers..)
- Add testing for setups with no CUDA (installer is now skipped with `CUDA = nill`)