### PR TITLE
Add `usable_cuda_gpus()` as non-noisy alternative to `has_cuda_gpu()`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,7 @@ end
 @testset "availability" begin
     @test isa(has_cuda(), Bool)
     @test isa(has_cuda_gpu(), Bool)
+    @test isa(usable_cuda_gpus(), Int)
 end
 
 @testset "call" begin


### PR DESCRIPTION
Closes #105.